### PR TITLE
Add support for Windows Hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,166 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+TXM_GUI2.ipynb
+TXM_Sandbox/config/analysis_tool_gui_cfg.json
+TXM_GUI2.ipynb
+TXM_Sandbox/config/io_tomo_h5_data_structure.json
+TXM_Sandbox/config/io_tomo_h5_data_structure.json
+TXM_GUI2.ipynb

--- a/README.md
+++ b/README.md
@@ -2,14 +2,25 @@
 This is a GUI program based on Jupyter that integrates tomography reconstruction and 2D/3D XANES data analysis. It provides a mechanism that allows users to customize the input data file formats.
 
 
-Installation
+## Installation (Linux)
   via conda-forge
 
 	conda create -n pytxm python=3.10 txm_sandbox -c conda-forge
 	conda activate pytxm
 
+## Installation (Windows)
 
-Usage
+Revised for Windows by Adrian Francisco Duran Ornelas, afornela@uci.edu, @afornelas
+
+Install miniconda3 from [https://docs.conda.io/projects/miniconda/en/latest/index.html](https://docs.conda.io/projects/miniconda/en/latest/index.html)
+
+Open the Anaconda Powershell Prompt (miniconda3) and run
+
+	conda create -n pytxm python=3.8 txm_sandbox -c conda-forge
+	conda activate pytxm
+
+## Usage
+
   You also need to install Fiji/ImageJ in your computer. After installing Fiji, you will need to update ImageJ then Fiji from its 'Help' menu. Restart Fiji after the updates.
 
   You will need to copy TXM_GUI2.ipynb into a working directory. Change to that working directory, then run
@@ -22,11 +33,10 @@ Usage
 
 includes the Fiji path as its argument. Change the path to your Fiji installation path. Click on the first cell and do shift+enter will run this cell. This will bring up TXM_Sandbox GUI. 
 
+## References:
 
-References:
   Please cite these two papers if you use TXM_Sandbox in your works.
 
 1. Xiao, X., Xu, Z., Lin, F. & Lee, W.-K., "TXM-Sandbox: an open-source software for transmission X-ray microscopy data analysis" (2022). J. Synchrotron Rad. 29, 266-275. https://doi.org/10.1107/S1600577521011978
 
 2. Xiao, X., Xu, Z., Hou, D., Yang, Z. & Lin, F., "Rigid registration algorithm based on the minimization of the total variation of the difference map" (2022). J. Synchrotron Rad. 29, 1085-1094. https://doi.org/10.1107/S1600577522005598
- 

--- a/TXM_Sandbox/gui/tomo_gui.py
+++ b/TXM_Sandbox/gui/tomo_gui.py
@@ -3769,7 +3769,7 @@ class tomo_recon_gui:
             code[ln] = f"run_engine(**params)"
             ln += 1
             gen_external_py_script(self.tomo_recon_external_command_name, code)
-            sig = os.system(f"python {self.tomo_recon_external_command_name}")
+            sig = os.system(f'python "{self.tomo_recon_external_command_name}"')
             if sig == 0:
                 boxes = ["TrialCenPrev box"]
                 enable_disable_boxes(self.hs, boxes, disabled=False, level=-1)
@@ -3828,9 +3828,7 @@ class tomo_recon_gui:
                         gen_external_py_script(
                             self.tomo_recon_external_command_name, code
                         )
-                        sig = os.system(
-                            f"python {self.tomo_recon_external_command_name}"
-                        )
+                        sig = os.system(f'python "{self.tomo_recon_external_command_name}"')
 
                         if sig == 0:
                             print(f"Reconstruction of {key} is done.")

--- a/TXM_Sandbox/gui/tomo_gui.py
+++ b/TXM_Sandbox/gui/tomo_gui.py
@@ -3766,7 +3766,9 @@ class tomo_recon_gui:
             ln += 1
             code[ln] = f"    self.info_reader = data_info(user_tomo_info_reader)"
             ln += 1
-            code[ln] = f"run_engine(**params)"
+            code[ln] = f"if __name__ == '__main__':"
+            ln += 1
+            code[ln] = f"    run_engine(**params)"
             ln += 1
             gen_external_py_script(self.tomo_recon_external_command_name, code)
             sig = os.system(f'python "{self.tomo_recon_external_command_name}"')
@@ -3823,7 +3825,9 @@ class tomo_recon_gui:
                             ln
                         ] = f"params['file_params']['info_reader'] = data_info(tomo_h5_info)"
                         ln += 1
-                        code[ln] = f"run_engine(**params)"
+                        code[ln] = f"if __name__ == '__main__':"
+                        ln += 1
+                        code[ln] = f"    run_engine(**params)"
                         ln += 1
                         gen_external_py_script(
                             self.tomo_recon_external_command_name, code

--- a/TXM_Sandbox/utils/tomo_recon_tools.py
+++ b/TXM_Sandbox/utils/tomo_recon_tools.py
@@ -366,16 +366,16 @@ def read_data(reader, fn, cfg, sli_start=0, sli_end=20,
 
 
 def retrieve_phase(data, pixel_size=1e-4, dist=50, energy=20,
-                   alpha=1e-3, pad=True, filter='paganin'):
+                   alpha=1e-3, pad=True, filter='paganin',ncore=None):
     if filter == 'paganin':
         data[:] = tomopy.prep.phase.retrieve_phase(data, pixel_size=pixel_size,
                                                    dist=dist, energy=energy,
-                                                   alpha=alpha, pad=pad)[:]
+                                                   alpha=alpha, pad=pad,ncore=ncore)[:]
     elif filter == 'bronnikov':
         data[:] = (1 - data)[:]
         data[:] = tomopy.prep.phase.retrieve_phase(data, pixel_size=pixel_size,
                                                    dist=dist, energy=energy,
-                                                   alpha=alpha, pad=pad)[:]
+                                                   alpha=alpha, pad=pad,ncore=ncore)[:]
     return data
 
 
@@ -656,6 +656,9 @@ def run_filter(data, flt):
     flt_name = flt['filter_name']
     params = translate_params(flt['params'])
     print('running', flt_name)
+    if os.name == 'nt' and os.cpu_count > 63: # Only run on Windows, and only for certain filters, solution to _winapi.WaitForMultipleObjects max 63 objects
+        if 'stripe_removal' in flt_name or 'phase retrieval' in flt_name:
+            params['ncore'] = 40
     if flt_name == "denoise: wiener":
         psfw = int(params['psf'])
         params['psf'] = np.ones([psfw, psfw]) / (psfw ** 2)


### PR DESCRIPTION
The following changes enable TXM_Sandbox to be run on Windows hosts (Tested on Windows 11, Windows 10) smoothly and efficiently.

Detailed writeups of problem solutions and commented codes are available in the individual commits that make up the pull request. Primarily the issues that were solved are enabling whitespace in external command path, windows multiprocessing support using the correct syntax for "spawn" as opposed to "fork" (Linux hosts unchanged), windows limitation fixes: _winapi.WaitForMultipleObjects maximum of 63 is now respected, and all physical cores continue to be saturated) (Linux hosts again unchanged).

Lastly, a small addendum is added to the README.md with the commands that are needed to install TXM_Sandbox in Windows through anaconda without the ImageJ dependency conflict on Python 3.10.

Adapted for the Kisailus BNM in house data processing computer running Windows 10 Pro 22H2. On our copy of the software, I've "installed" TXM_Sandbox as a "native" app with a desktop icon in order to facilitate usage of the program by undergraduates without CS experience. If this is a feature you'd like other researchers to share I could additionally parameterize it and submit it in a future pull request.